### PR TITLE
Remove workaround for Location_LEVEL nullability in dv-export example script

### DIFF
--- a/dv-export/python/constants.py
+++ b/dv-export/python/constants.py
@@ -12,7 +12,6 @@ EXPORT_JOB_FAILED_KEY = 'failed'
 EXPORT_JOB_COMPLETED_KEY = 'completed'
 
 # Export metadata related constants
-LOCATION_LEVEL_COLUMN_NAME = 'Location_LEVEL'
 DIFF_ACTION_COLUMN_NAME = '_DiffAction_'
 DIFF_ACTION_INSERT = '+'
 UUID_KEY = 'uuid'

--- a/dv-export/python/data_store.py
+++ b/dv-export/python/data_store.py
@@ -78,17 +78,12 @@ class SQLAlchemyDataStore(DataStore):
             name = column_info.name
             sql_data_type = self.get_data_store_data_type_from_dv_export_data_type(column_info.data_type)
 
-            if column_info.name == LOCATION_LEVEL_COLUMN_NAME:
-                nullable = True
-            else:
-                nullable = column_info.allows_null
-
             columns.append(
                 Column(
                     name,
                     sql_data_type,
                     primary_key=column_info.primary_key,
-                    nullable=nullable
+                    nullable=column_info.allows_null
                 )
             )
         return columns


### PR DESCRIPTION
This PR removes the workaround to always set the value of `allowsNull` to `true` for the `Location_LEVEL` column in any exported table. The bug requiring this workaround has been resolved in the DV Export API through ticket VAN-120816. 

The DV Export API can now be trusted to correctly report if a column allows null or not.

Previously, an exception was encountered in the script when trying to write records for the table `Scheduled_Hours` in the data version for the test tenant `d3m`. This was because DV export would report `Location_LEVEL` as not nullable but export data with null data in that column. This would cause a SQL exception due to writing null in a non-null column. Now, the script exports all tables from `d3m` without issue.