### PR TITLE
Migrate export-to-database DV export sample to use the Visier Platform SDK instead

### DIFF
--- a/dv-export/python/export-to-database/.env.visier-auth
+++ b/dv-export/python/export-to-database/.env.visier-auth
@@ -1,8 +1,19 @@
-# Visier auth variables
+# Required for all authentication methods.
 VISIER_HOST=https://customer-specific.api.visier.io
-VISIER_CLIENT_ID='client-id-from-registration'
-VISIER_CLIENT_SECRET='client-secret-from-registration'
 VISIER_APIKEY='visier-provided-api-key'
+VISIER_VANITY='visier-tenant-vanity-name'
+
+# Required for OAuth 2.0 authentication.
+VISIER_CLIENT_ID='client-id-from-registration'  # Retrieve the client ID from your client registration in Visier.
+VISIER_CLIENT_SECRET='client-secret-from-registration'  # Retrieve the client secret from your client registration in Visier.
+
+# For 3-legged OAuth 2.0 authentication, provide a redirect URI in addition to the VISIER_CLIENT_ID and VISIER_CLIENT_SECRET. The redirect URI must be registered in Visier. The client starts a local server to handle the callback. The default is http://localhost:5000/oauth2/callback.
+VISIER_REDIRECT_URI='http://localhost:5000/oauth2/callback'
+
+# For basic authentication, provide only the VISIER_USERNAME and VISIER_PASSWORD. Leave VISIER_CLIENT_ID and VISIER_CLIENT_SECERT blank.
+# For 2-legged OAuth 2.0 authentication, provide the VISIER_USERNAME, VISIER_PASSWORD, VISIER_CLIENT_ID, and VISIER_CLIENT_SECRET.
 VISIER_USERNAME='visier-username'
 VISIER_PASSWORD='visier-password'
-VISIER_VANITY='visier-tenant-vanity-name'
+
+# Optional: Tenant code for operations that require it
+VISIER_TENANT_CODE='tenant-code'

--- a/dv-export/python/export-to-database/constants.py
+++ b/dv-export/python/export-to-database/constants.py
@@ -5,30 +5,9 @@ DELETE_BASE_DOWNLOAD_DIRECTORY_AFTER_EXPORT = 'DELETE_BASE_DOWNLOAD_DIRECTORY_AF
 BASE_DOWNLOAD_DIRECTORY = 'BASE_DOWNLOAD_DIRECTORY'
 DB_URL = 'DB_URL'
 
-# Export job related constants
-JOB_UUID_KEY = 'jobUuid'
-EXPORT_UUID_KEY = 'exportUuid'
-EXPORT_JOB_FAILED_KEY = 'failed'
-EXPORT_JOB_COMPLETED_KEY = 'completed'
-
 # Export metadata related constants
 DIFF_ACTION_COLUMN_NAME = '_DiffAction_'
 DIFF_ACTION_INSERT = '+'
-UUID_KEY = 'uuid'
-TABLES_KEY = 'tables'
-NEW_TABLES_KEY = 'newTables'
-DELETED_TABLES_KEY = 'deletedTables'
-NAME_KEY = 'name'
-COLUMNS_KEY = 'columns'
-COMMON_COLUMNS_KEY = 'commonColumns'
-NEW_COLUMNS_KEY = 'newColumns'
-DELETED_COLUMNS_KEY = 'deletedColumns'
-FILES_KEY = 'files'
-FILE_ID_KEY = 'fileId'
-FILENAME_KEY = 'filename'
-DATA_TYPE_KEY = 'dataType'
-ALLOWS_NULL_KEY = 'allowsNull'
-IS_PRIMARY_KEY_COMPONENT_KEY = 'isPrimaryKeyComponent'
 
 # Pandas DataFrame Dtype constants (see https://pandas.pydata.org/pandas-docs/stable/user_guide/basics.html#dtypes)
 PANDAS_DF_NULLABLE_INTEGER_INT64_DTYPE = 'Int64'

--- a/dv-export/python/export-to-database/dv_export.py
+++ b/dv-export/python/export-to-database/dv_export.py
@@ -101,24 +101,19 @@ class DVExport:
         for file_info in file_infos:
             logger.info(f"Downloading file={file_info.name} with id={file_info.file_id} for table={tbl_name}")
 
-            # There are three possible functions to call to download an individual file from the export; in this
-            # case, we're using the first one, but the methods to call the others are provided as examples
+            # Get the ApiResponse
+            api_response = self.client.call_1_alpha_download_file_with_http_info(export_uuid=export_uuid, file_id=file_info.file_id)
+            if api_response.status_code == 200:
+                file_path = download_directory + file_info.name
+                with open(file_path, 'wb') as f:
+                    f.write(api_response.data)
+                file_paths.append(file_path)
+                logger.info(f"Downloaded file={file_info.name} with id={file_info.file_id} "
+                            f"for table={tbl_name} to file={file_path}")
+            else:
+                raise Exception(f"Failed to download file={file_info.name} with id={file_info.file_id} "
+                                f"for table={tbl_name}. Status code: {api_response.status_code}")
 
-            # Method 1: Returns the bytearray of the file
-            r = self.client.call_1_alpha_download_file(export_uuid=export_uuid, file_id=file_info.file_id)
-
-            # Method 2: Returns an ApiResponse with the bytearray as the data
-            #r = self.client.call_1_alpha_download_file_with_http_info(export_uuid=export_uuid, file_id=file_info.file_id).data
-
-            # Method 3: Return the response through a HTTPResponse
-            #r = self.client.call_1_alpha_download_file_without_preload_content(export_uuid=export_uuid, file_id=file_info.file_id).data
-
-            file_path = download_directory + file_info.name
-            with open(file_path, 'wb') as f:
-                f.write(r)
-            file_paths.append(file_path)
-            logger.info(f"Downloaded file={file_info.name} with id={file_info.file_id} "
-                        f"for table={tbl_name} to file={file_path}")
         return file_paths
 
     def _create_and_populate_new_table(self,

--- a/dv-export/python/export-to-database/dv_export.py
+++ b/dv-export/python/export-to-database/dv_export.py
@@ -22,16 +22,16 @@ class DVExport:
         self.base_download_dir = base_download_dir
 
     def generate_data_version_export(self,
-                                     data_version_number: str,
-                                     base_data_version_number: Optional[str],
+                                     data_version_number: int,
+                                     base_data_version_number: Optional[int],
                                      mx_num_polls: int,
                                      poll_interval_secs: int
                                      ) -> DataVersionExportDTO:
 
         # Schedule a new export job
         dv_export_schedule_job_request_dto = DataVersionExportScheduleJobRequestDTO(
-            data_version_number=data_version_number,
-            base_data_version_number=base_data_version_number if base_data_version_number else None
+            data_version_number=str(data_version_number),
+            base_data_version_number=str(base_data_version_number) if base_data_version_number else None
         )
 
         job_id = self._schedule_export_job(dv_export_schedule_job_request_dto)

--- a/dv-export/python/export-to-database/dv_export.py
+++ b/dv-export/python/export-to-database/dv_export.py
@@ -3,13 +3,13 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
-from visier.api import DVExportApiClient
+
 from visier_platform_sdk import ApiClient, DataVersionExportApi, DataVersionExportScheduleJobRequestDTO, \
     DataVersionExportDTO, ApiException
 
+from constants import *
 from data_store import DataStore
 from dv_export_model import FileInfo, TableInfo, ColumnInfoAndFileInfo, convert_table_metadata_into_table_infos
-from constants import *
 
 logger = logging.getLogger('dv_export')
 
@@ -167,7 +167,7 @@ class DVExport:
 
     def _handle_delta_export(self,
                              tables: list[TableInfo],
-                             metadata: dict[str, any],
+                             metadata: DataVersionExportDTO,
                              export_id: str):
         """
         Handle a delta export, where there could be new, existing, and/or deleted tables to operate on.
@@ -177,12 +177,12 @@ class DVExport:
         """
         logger.info(f"Performing delta export")
 
-        deleted_tables = metadata[DELETED_TABLES_KEY]
+        deleted_tables = metadata.deleted_tables
         for deleted_table in deleted_tables:
             logger.info(f"Dropping table={deleted_table}")
             self.data_store.drop_table(deleted_table)
 
-        new_tables = metadata[NEW_TABLES_KEY]
+        new_tables = metadata.new_tables
         new_table_infos = [tbl_info for tbl_info in tables if tbl_info.name in new_tables]
 
         self._create_and_populate_new_tables(new_table_infos, export_id)
@@ -214,7 +214,7 @@ class DVExport:
         :param metadata: Full export metadata returned from a DV export job
         """
         export_id = metadata.uuid
-        tables = convert_table_metadata_into_table_infos(metadata.to_dict()['tables'])
+        tables = convert_table_metadata_into_table_infos(metadata.tables)
 
         is_initial_export = (len(metadata.tables) if metadata.tables else 0) == (len(metadata.new_tables) if metadata.new_tables else 0)
 

--- a/dv-export/python/export-to-database/dv_export.py
+++ b/dv-export/python/export-to-database/dv_export.py
@@ -4,6 +4,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 from visier.api import DVExportApiClient
+from visier_platform_sdk import ApiClient, DataVersionExportApi, DataVersionExportScheduleJobRequestDTO, \
+    DataVersionExportDTO, ApiException
+
 from data_store import DataStore
 from dv_export_model import FileInfo, TableInfo, ColumnInfoAndFileInfo, convert_table_metadata_into_table_infos
 from constants import *
@@ -21,69 +24,73 @@ class DVExport:
     """
     Orchestrates interactions between the ``DVExportApiClient`` and the output ``DataStore``
     """
-    def __init__(self, client: DVExportApiClient, data_store: DataStore, base_download_dir: str):
-        self.client = client
+    def __init__(self, client: ApiClient, data_store: DataStore, base_download_dir: str):
+        self.client = DataVersionExportApi(client)
         self.data_store = data_store
         self.base_download_dir = base_download_dir
 
     def generate_data_version_export(self,
-                                     dv_info: DataVersions,
+                                     dv_export_schedule_job_request_dto: DataVersionExportScheduleJobRequestDTO,
                                      mx_num_polls: int,
-                                     poll_interval_secs: int) -> dict[str, any]:
-        job_id = self._schedule_export_job(dv_info)
+                                     poll_interval_secs: int
+                                     ) -> DataVersionExportDTO:
+        job_id = self._schedule_export_job(dv_export_schedule_job_request_dto)
         export_id = self._get_export_id_when_job_finishes(job_id, mx_num_polls, poll_interval_secs)
-        metadata: dict[str, any] = self.get_export_metadata(export_id)
-        return metadata
+        return self.get_export_metadata(export_id)
 
-    def _schedule_export_job(self, dv_info: DataVersions) -> str:
-        logger.info(f"Scheduling a data version export job for data_version_number={dv_info.data_version_number} "
-                    f"base_data_version_number={dv_info.base_data_version_number}")
-        if dv_info.base_data_version_number is None:
-            schedule_response = self.client.schedule_initial_data_version_export_job(dv_info.data_version_number)
-        else:
-            schedule_response = self.client.schedule_delta_data_version_export_job(dv_info.data_version_number,
-                                                                                   dv_info.base_data_version_number)
-        job_id: str = schedule_response.json()[JOB_UUID_KEY]
-        logger.info(f'Scheduled data version export job with job_id={job_id}')
-        return job_id
+    def _schedule_export_job(self,
+                             dv_export_schedule_job_request_dto: DataVersionExportScheduleJobRequestDTO
+                             ) -> str:
+        logger.info(f"Scheduling a data version export job for data_version_number={dv_export_schedule_job_request_dto.data_version_number} "
+                    f"base_data_version_number={dv_export_schedule_job_request_dto.base_data_version_number}")
+        try:
+            response = self.client.schedule_export_job(dv_export_schedule_job_request_dto)
+            job_id = response.job_uuid
+            logger.info(f"Scheduled data version export job with {job_id=}")
+            return job_id
+        except ApiException as e:
+            raise Exception(f"Failed to schedule data version export job with {dv_export_schedule_job_request_dto=}\n{e.body}", e)
 
     def _get_export_id_when_job_finishes(self,
                                          job_id: str,
                                          mx_num_polls: int,
                                          poll_interval_secs: int) -> str:
-        curr_poll = 0
-        export_id = ""
-        while curr_poll < mx_num_polls:
-            status_response = self.client.get_data_version_export_job_status(job_id)
-            if not status_response:
-                raise Exception(f"Failed to get export job status for job_id={job_id} response={repr(status_response)}")
+        export_id = None
+        counter = 1
+        while counter <= mx_num_polls:
+            try:
+                job_status = self.client.get_export_job_status(job_id)
 
-            status_response_json = status_response.json()
-            if status_response_json[EXPORT_JOB_FAILED_KEY]:
-                raise Exception(f"Data version export job_id={job_id} failed")
+                if job_status.failed:
+                    raise Exception(f"Data version export {job_id=} failed")
 
-            if status_response_json[EXPORT_JOB_COMPLETED_KEY]:
-                export_id = status_response_json[EXPORT_UUID_KEY]
-                logger.info(f"Export job_id={job_id} completed with export_id={export_id}")
-                break
+                if job_status.completed:
+                    export_id = job_status.export_uuid
+                    logger.info(f"Export {job_id=} completed with {export_id=}")
+                    break
 
-            repeat_msg = f"Trying again in {poll_interval_secs} seconds" if curr_poll != mx_num_polls - 1 else ""
-            logger.info(
-                f"(Attempt {curr_poll + 1} out of {mx_num_polls}) job_id={job_id} is still running. {repeat_msg}")
-            if curr_poll != mx_num_polls - 1:
-                time.sleep(poll_interval_secs)
-            curr_poll = curr_poll + 1
+                repeat_msg = f"Trying again in {poll_interval_secs} seconds" if counter <= mx_num_polls else ""
+                logger.info(f"(Attempt {counter} out of {mx_num_polls}) {job_id=} is still running. {repeat_msg}")
+                if repeat_msg:
+                    time.sleep(poll_interval_secs)
 
-        if export_id == "":
-            raise Exception(f"Failed to retrieve export_id after {curr_poll} polls")
+            except ApiException as e:
+                raise Exception(f"Failed to get export job status for {job_id=} response={repr(job_status)}\n{e.body}", e)
+
+            finally:
+                counter += 1
+
+        if export_id is None:
+            raise Exception(f"Failed to retrieve export_id after {mx_num_polls} attempts")
         return export_id
 
-    def get_export_metadata(self, export_id: str) -> dict[str, any]:
-        metadata_response = self.client.get_data_version_export_metadata(export_id)
-        if not metadata_response:
-            raise Exception(f"Failed to get export metadata for export_id={export_id}")
-        logger.info(f"Successfully retrieved metadata for export_id={export_id}")
-        return metadata_response.json()
+    def get_export_metadata(self, export_id: str) -> DataVersionExportDTO:
+        try:
+            response = self.client.get_export(export_id)
+            logger.info(f"Successfully retrieved export metadata for {export_id=}")
+            return response
+        except ApiException as e:
+            raise Exception(f"Failed to get export metadata for {export_id=}\n{e.body}", e)
 
     def _download_table_files_to_dir(self,
                                      export_uuid: str,
@@ -93,14 +100,23 @@ class DVExport:
         file_paths = []
         for file_info in file_infos:
             logger.info(f"Downloading file={file_info.name} with id={file_info.file_id} for table={tbl_name}")
-            with self.client.get_export_file(export_uuid, file_id=file_info.file_id) as r:
-                r.raise_for_status()
-                file_path = download_directory + file_info.name
-                with open(file_path, 'wb') as f:
-                    for chunk in r.iter_content(chunk_size=None):
-                        if chunk:
-                            f.write(chunk)
-                file_paths.append(file_path)
+
+            # There are three possible functions to call to download an individual file from the export; in this
+            # case, we're using the first one, but the methods to call the others are provided as examples
+
+            # Method 1: Returns the bytearray of the file
+            r = self.client.call_1_alpha_download_file(export_uuid=export_uuid, file_id=file_info.file_id)
+
+            # Method 2: Returns an ApiResponse with the bytearray as the data
+            #r = self.client.call_1_alpha_download_file_with_http_info(export_uuid=export_uuid, file_id=file_info.file_id).data
+
+            # Method 3: Return the response through a HTTPResponse
+            #r = self.client.call_1_alpha_download_file_without_preload_content(export_uuid=export_uuid, file_id=file_info.file_id).data
+
+            file_path = download_directory + file_info.name
+            with open(file_path, 'wb') as f:
+                f.write(r)
+            file_paths.append(file_path)
             logger.info(f"Downloaded file={file_info.name} with id={file_info.file_id} "
                         f"for table={tbl_name} to file={file_path}")
         return file_paths
@@ -190,17 +206,17 @@ class DVExport:
             itr += 1
 
     def process_metadata(self,
-                         metadata: dict[str, any]):
+                         metadata: DataVersionExportDTO):
         """
         Use the DV export metadata to create or update table definitions in output data store, download files for
         those tables, then insert records from those files into output data store.
 
         :param metadata: Full export metadata returned from a DV export job
         """
-        tables = convert_table_metadata_into_table_infos(metadata[TABLES_KEY])
-        export_id = metadata[UUID_KEY]
+        export_id = metadata.uuid
+        tables = convert_table_metadata_into_table_infos(metadata.to_dict()['tables'])
 
-        is_initial_export = len(metadata[TABLES_KEY]) == len(metadata[NEW_TABLES_KEY])
+        is_initial_export = (len(metadata.tables) if metadata.tables else 0) == (len(metadata.new_tables) if metadata.new_tables else 0)
 
         if is_initial_export:
             self._create_and_populate_new_tables(tables, export_id)

--- a/dv-export/python/export-to-database/dv_export.py
+++ b/dv-export/python/export-to-database/dv_export.py
@@ -1,23 +1,15 @@
 import logging
 import time
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
 from visier_platform_sdk import ApiClient, DataVersionExportApi, DataVersionExportScheduleJobRequestDTO, \
     DataVersionExportDTO, ApiException
 
-from constants import *
 from data_store import DataStore
 from dv_export_model import FileInfo, TableInfo, ColumnInfoAndFileInfo, convert_table_metadata_into_table_infos
 
 logger = logging.getLogger('dv_export')
-
-
-@dataclass
-class DataVersions:
-    data_version_number: int
-    base_data_version_number: Optional[int]
 
 
 class DVExport:
@@ -30,10 +22,18 @@ class DVExport:
         self.base_download_dir = base_download_dir
 
     def generate_data_version_export(self,
-                                     dv_export_schedule_job_request_dto: DataVersionExportScheduleJobRequestDTO,
+                                     data_version_number: str,
+                                     base_data_version_number: Optional[str],
                                      mx_num_polls: int,
                                      poll_interval_secs: int
                                      ) -> DataVersionExportDTO:
+
+        # Schedule a new export job
+        dv_export_schedule_job_request_dto = DataVersionExportScheduleJobRequestDTO(
+            data_version_number=data_version_number,
+            base_data_version_number=base_data_version_number if base_data_version_number else None
+        )
+
         job_id = self._schedule_export_job(dv_export_schedule_job_request_dto)
         export_id = self._get_export_id_when_job_finishes(job_id, mx_num_polls, poll_interval_secs)
         return self.get_export_metadata(export_id)

--- a/dv-export/python/export-to-database/dv_export_model.py
+++ b/dv-export/python/export-to-database/dv_export_model.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from enum import Enum
-from constants import *
+
+from visier_platform_sdk import DataVersionExportTableDTO, DataVersionExportFileDTO, DataVersionExportColumnDTO, \
+    DataVersionExportPartFileDTO
 
 
 class DVExportDataType(Enum):
@@ -51,7 +53,7 @@ class TableInfo:
     columns: ColumnsMetadata
 
 
-def convert_table_metadata_into_table_infos(tables_metadata: list[dict[str, any]]) -> list[TableInfo]:
+def convert_table_metadata_into_table_infos(tables_metadata: list[DataVersionExportTableDTO]) -> list[TableInfo]:
     """
     Converts a list of tables from export metadata into a list of ``TableInfo``. Each ``table`` in ``tables_metadata``
     has a name and some column metadata. The column metadata includes a name, data type, whether the column allows null,
@@ -65,23 +67,20 @@ def convert_table_metadata_into_table_infos(tables_metadata: list[dict[str, any]
 
     A ``TableInfo`` object encapsulates all of this.
 
-    :param tables_metadata: A list of tables which came from a DV export metadata response
+    :param tables_metadata: A list of ``DataVersionExportTableDTO`` which came from a DV export metadata response
     :return: A list of ``TableInfo`` objects which encapsulate the required metadata to create or update a table from
         a DV export
     """
     tables: list[TableInfo] = []
 
     for table_metadata in tables_metadata:
-        table_name = table_metadata[NAME_KEY]
-        common_columns_and_files = table_metadata[COMMON_COLUMNS_KEY]
-        new_columns_and_files = table_metadata[NEW_COLUMNS_KEY]
-        deleted_columns = table_metadata[DELETED_COLUMNS_KEY]
+        table_name = table_metadata.name
+        common_columns_and_files = table_metadata.common_columns
+        new_columns_and_files = table_metadata.new_columns
+        deleted_columns = table_metadata.deleted_columns
 
-        common_columns_column_infos = _convert_column_metadata_into_column_infos(common_columns_and_files[COLUMNS_KEY])
-        common_columns_file_infos = _convert_file_metadata_into_file_infos(common_columns_and_files[FILES_KEY])
-
-        new_columns_column_infos = _convert_column_metadata_into_column_infos(new_columns_and_files[COLUMNS_KEY])
-        new_columns_file_infos = _convert_file_metadata_into_file_infos(new_columns_and_files[FILES_KEY])
+        common_columns_column_infos, common_columns_file_infos = _convert_metadata_into_infos(common_columns_and_files)
+        new_columns_column_infos, new_columns_file_infos = _convert_metadata_into_infos(new_columns_and_files)
 
         tables.append(TableInfo(
             table_name,
@@ -95,37 +94,22 @@ def convert_table_metadata_into_table_infos(tables_metadata: list[dict[str, any]
     return tables
 
 
-def _convert_file_metadata_into_file_infos(files_metadata: list[dict]) -> list[FileInfo]:
-    """
-    Converts a list of files from export metadata into a list of ``FileInfo``. A file has metadata describing its
-    name and ID. The ID is used to identify the file when downloading from the DV export API in combination with the
-    export UUID.
-    :param files_metadata:
-    :return: A list of ``FileInfo`` objects which encapsulate the required metadata to download files for specific
-        columns from a DV export
-    """
-    file_infos = []
-    for file in files_metadata:
-        file_id = file[FILE_ID_KEY]
-        file_name = file[FILENAME_KEY]
-        file_infos.append(FileInfo(file_id, file_name))
-    return file_infos
+def _convert_metadata_into_infos(metadata: DataVersionExportFileDTO) -> (list[ColumnInfo], list[FileInfo]):
+    column_infos = [_convert_to_column_info(column) for column in metadata.columns]
+    file_infos = [_convert_to_file_info(file) for file in metadata.files]
+    return column_infos, file_infos
 
 
-def _convert_column_metadata_into_column_infos(columns_metadata: list[dict]) -> list[ColumnInfo]:
-    """
-    Converts a list of columns from export metadata into a list of ``ColumnInfo``. A column has metadata describing
-    its name, data type, whether it allows null, and whether it's a part of the primary key for the table.
-    :param columns_metadata: List of columns which came from a DV export metadata response
-    :return: A list of ``ColumnInfo`` objects which encapsulate the required metadata to create or update a column from
-        a DV export
-    """
-    column_infos = []
-    for common_column in columns_metadata:
-        name = common_column[NAME_KEY]
-        data_type: str = common_column[DATA_TYPE_KEY]
-        data_type_enum: DVExportDataType = string_to_data_type(data_type)
-        allows_null = bool(common_column[ALLOWS_NULL_KEY])
-        is_primary_key = bool(common_column[IS_PRIMARY_KEY_COMPONENT_KEY])
-        column_infos.append(ColumnInfo(name, data_type_enum, allows_null, is_primary_key))
-    return column_infos
+def _convert_to_column_info(column: DataVersionExportColumnDTO) -> ColumnInfo:
+    name = column.name
+    data_type = column.data_type
+    data_type_enum: DVExportDataType = string_to_data_type(data_type)
+    allows_null = column.allows_null
+    is_primary_key = column.is_primary_key_component
+    return ColumnInfo(name, data_type_enum, allows_null, is_primary_key)
+
+
+def _convert_to_file_info(part_file: DataVersionExportPartFileDTO) -> FileInfo:
+    file_id = part_file.file_id
+    file_name = part_file.filename
+    return FileInfo(file_id, file_name)

--- a/dv-export/python/export-to-database/dv_export_model.py
+++ b/dv-export/python/export-to-database/dv_export_model.py
@@ -75,18 +75,15 @@ def convert_table_metadata_into_table_infos(tables_metadata: list[DataVersionExp
 
     for table_metadata in tables_metadata:
         table_name = table_metadata.name
-        common_columns_and_files = table_metadata.common_columns
-        new_columns_and_files = table_metadata.new_columns
+        common_columns_and_files = _convert_metadata_into_infos(table_metadata.common_columns)
+        new_columns_and_files = _convert_metadata_into_infos(table_metadata.new_columns)
         deleted_columns = table_metadata.deleted_columns
-
-        common_columns_column_infos, common_columns_file_infos = _convert_metadata_into_infos(common_columns_and_files)
-        new_columns_column_infos, new_columns_file_infos = _convert_metadata_into_infos(new_columns_and_files)
 
         tables.append(TableInfo(
             table_name,
             ColumnsMetadata(
-                ColumnInfoAndFileInfo(common_columns_column_infos, common_columns_file_infos),
-                ColumnInfoAndFileInfo(new_columns_column_infos, new_columns_file_infos),
+                common_columns_and_files,
+                new_columns_and_files,
                 deleted_columns
             )
         ))
@@ -94,10 +91,10 @@ def convert_table_metadata_into_table_infos(tables_metadata: list[DataVersionExp
     return tables
 
 
-def _convert_metadata_into_infos(metadata: DataVersionExportFileDTO) -> (list[ColumnInfo], list[FileInfo]):
+def _convert_metadata_into_infos(metadata: DataVersionExportFileDTO) -> ColumnInfoAndFileInfo:
     column_infos = [_convert_to_column_info(column) for column in metadata.columns]
     file_infos = [_convert_to_file_info(file) for file in metadata.files]
-    return column_infos, file_infos
+    return ColumnInfoAndFileInfo(column_infos, file_infos)
 
 
 def _convert_to_column_info(column: DataVersionExportColumnDTO) -> ColumnInfo:

--- a/dv-export/python/export-to-database/main.py
+++ b/dv-export/python/export-to-database/main.py
@@ -1,11 +1,14 @@
 import argparse
 import shutil
+import time
 
 from dotenv import dotenv_values
 from visier_platform_sdk import ApiClient, Configuration, DataVersionExportApi, DataVersionExportScheduleJobRequestDTO, \
     DataVersionExportDTO
 from visier.connector import VisierSession, make_auth
 from visier.api import DVExportApiClient
+from visier_platform_sdk.exceptions import ServiceException, ApiException
+
 from data_store import *
 from dv_export import DVExport, DataVersions
 from constants import *
@@ -47,10 +50,13 @@ max_num_polls = int(config_dict[JOB_STATUS_NUM_POLLS])
 poll_interval_seconds = int(config_dict[JOB_STATUS_POLL_INTERVAL_SECONDS])
 delete_downloaded_files = True if config_dict[DELETE_BASE_DOWNLOAD_DIRECTORY_AFTER_EXPORT].upper() == 'TRUE' else False
 base_download_directory = config_dict[BASE_DOWNLOAD_DIRECTORY]
-store = SQLAlchemyDataStore(config_dict[DB_URL])
+#store = SQLAlchemyDataStore(config_dict[DB_URL])
 
 if args.mode == 'legacy':
+
+
     logger.info("Running DV Export in legacy mode...")
+    store = SQLAlchemyDataStore(config_dict[DB_URL])
 
     auth = make_auth(env_values=config_dict)
     with VisierSession(auth) as s:
@@ -74,11 +80,128 @@ if args.mode == 'legacy':
             shutil.rmtree(base_download_directory)
 
 elif args.mode == 'sdk':
+    from dv_export_model import convert_table_metadata_into_table_infos, FileInfo
+
     logger.info("Running DV Export using the SDK...")
+    config_dict[DB_URL] = 'sqlite:///j1r-export-sdk-7000001.db'
+    store = SQLAlchemyDataStore(config_dict[DB_URL])
 
     config = Configuration.from_dict(config_dict)
     client = ApiClient(config)
-    data_version_export_api = DataVersionExportApi(client)
+
+    class DVExportNew(DVExport):
+        """ Wrapper class that interacts with the data version export APIs through the SDK."""
+
+        def __init__(self, client: ApiClient, data_store: DataStore, base_download_directory: str):
+            self.client = DataVersionExportApi(client)
+            self.data_store = data_store
+            self.base_download_dir = base_download_directory
+
+        def generate_data_version_export(self,
+                                         dv_export_schedule_job_request_dto: DataVersionExportScheduleJobRequestDTO,
+                                         max_num_polls: int,
+                                         poll_interval_secs: int
+                                         ):
+            job_id = self._schedule_export_job(dv_export_schedule_job_request_dto)
+            export_id = self._get_export_id_when_job_finishes(job_id, max_num_polls, poll_interval_secs)
+            return self.get_export_metadata(export_id)
+
+        def _schedule_export_job(self,
+                                 dv_export_schedule_job_request_dto: DataVersionExportScheduleJobRequestDTO):
+            logger.info(f"Scheduling a data version export job for data_version_number={dv_export_schedule_job_request_dto.data_version_number} "
+                        f"base_data_version_number={dv_export_schedule_job_request_dto.base_data_version_number}")
+
+            try:
+                response = self.client.schedule_export_job(dv_export_schedule_job_request_dto)
+                job_id = response.job_uuid
+                logger.info(f"Scheduled data version export job with {job_id=}")
+                return job_id
+            except ApiException as e:
+                raise Exception(f"Failed to schedule data version export job with {dv_export_schedule_job_request_dto=}\n{e.body}", e)
+
+        def _get_export_id_when_job_finishes(self,
+                                             job_id: str,
+                                             max_num_polls: int,
+                                             poll_interval_seconds: int) -> str:
+            export_id = None
+
+            counter = 1
+            while counter <= max_num_polls:
+                try:
+                    job_status = self.client.get_export_job_status(job_id)
+
+                    if job_status.failed:
+                        raise Exception(f"Data version export {job_id=} failed")
+
+                    if job_status.completed:
+                        export_id = job_status.export_uuid
+                        logger.info(f"Export {job_id=} completed with {export_id=}")
+                        break
+
+                    repeat_msg = f"Trying again in {poll_interval_seconds} seconds" if counter <= max_num_polls else ""
+                    logger.info(f"(Attempt {counter} out of {max_num_polls}) {job_id=} is still running. {repeat_msg}")
+                    if repeat_msg:
+                        time.sleep(poll_interval_seconds)
+
+                except ApiException as e:
+                    raise Exception(f"Failed to get export job status for {job_id=} response={repr(job_status)}\n{e.body}", e)
+
+                finally:
+                    counter += 1
+
+            if export_id is None:
+                raise Exception(f"Failed to retrieve export_id after {max_num_polls} attempts")
+            return export_id
+
+        def get_export_metadata(self, export_id: str) -> DataVersionExportDTO:
+            try:
+                response = self.client.get_export(export_id)
+                logger.info(f"Successfully retrieved export metadata for {export_id=}")
+                return response
+            except ApiException as e:
+                raise Exception(f"Failed to get export metadata for {export_id=}\n{e.body}", e)
+
+        def process_metadata(self, metadata: DataVersionExportDTO):
+            export_id = metadata.uuid
+            tables = convert_table_metadata_into_table_infos(metadata.to_dict()['tables'])
+
+            is_initial_export = (len(metadata.tables) if metadata.tables else 0) == (len(metadata.new_tables) if metadata.new_tables else 0)
+
+            if is_initial_export:
+                self._create_and_populate_new_tables(tables, export_id)
+            else:
+                self._handle_delta_export(tables, metadata, export_id)
+
+        def _download_table_files_to_dir(self,
+                                     export_uuid: str,
+                                     tbl_name: str,
+                                     file_infos: list[FileInfo],
+                                     download_directory: str) -> list[str]:
+            file_paths = []
+            for file_info in file_infos:
+                logger.info(f"Downloading file={file_info.name} with id={file_info.file_id} for table={tbl_name}")
+
+                # There are three possible functions to call to download an individual file from the export; in this
+                # case, we're using the first one, but the methods to call the others are provided as examples
+
+                # Method 1: Returns the bytearray of the file
+                r = self.client.call_1_alpha_download_file(export_uuid=export_uuid, file_id=file_info.file_id)
+
+                # Method 2: Returns an ApiResponse with the bytearray as the data
+                #r = self.client.call_1_alpha_download_file_with_http_info(export_uuid=export_uuid, file_id=file_info.file_id).data
+
+                # Method 3: Return the response through a HTTPResponse
+                #r = self.client.call_1_alpha_download_file_without_preload_content(export_uuid=export_uuid, file_id=file_info.file_id).data
+
+                file_path = download_directory + file_info.name
+                with open(file_path, 'wb') as f:
+                    f.write(r)
+                file_paths.append(file_path)
+                logger.info(f"Downloaded file={file_info.name} with id={file_info.file_id} "
+                            f"for table={tbl_name} to file={file_path}")
+            return file_paths
+
+    dv_export = DVExportNew(client, store, base_download_directory)
 
     if args.export_uuid is None:
 
@@ -87,17 +210,13 @@ elif args.mode == 'sdk':
             data_version_number=str(args.data_version),
             base_data_version_number=str(args.base_data_version) if args.base_data_version is not None else None
         )
-        logger.info(f"Scheduling a data version export job for data_version_number={dv_export_schedule_job_request_dto.data_version_number} "
-                    f"base_data_version_number={dv_export_schedule_job_request_dto.base_data_version_number}")
-        response = data_version_export_api.schedule_export_job(dv_export_schedule_job_request_dto)
 
-        # Monitor job status
-
-        # Return export metadata
-        export_metadata: DataVersionExportDTO = data_version_export_api.get_export(export_uuid=response.job_uuid)
+        export_metadata = dv_export.generate_data_version_export(dv_export_schedule_job_request_dto, max_num_polls, poll_interval_seconds)
 
     else:
-        export_metadata: DataVersionExportDTO = data_version_export_api.get_export(export_uuid=args.export_uuid)
+        export_metadata = dv_export.get_export_metadata(args.export_uuid)
 
-    # TODO Process the export metadata
-    # TODO cleanup files if needed
+    dv_export.process_metadata(export_metadata)
+
+    if delete_downloaded_files:
+        shutil.rmtree(base_download_directory)

--- a/dv-export/python/export-to-database/main.py
+++ b/dv-export/python/export-to-database/main.py
@@ -1,17 +1,11 @@
 import argparse
 import shutil
-import time
 
 from dotenv import dotenv_values
-from visier_platform_sdk import ApiClient, Configuration, DataVersionExportApi, DataVersionExportScheduleJobRequestDTO, \
-    DataVersionExportDTO
-from visier.connector import VisierSession, make_auth
-from visier.api import DVExportApiClient
-from visier_platform_sdk.exceptions import ServiceException, ApiException
+from visier_platform_sdk import ApiClient, Configuration, DataVersionExportScheduleJobRequestDTO
 
 from data_store import *
-from dv_export import DVExport, DataVersions
-from constants import *
+from dv_export import DVExport
 
 logging.basicConfig(
     level=logging.INFO,
@@ -38,8 +32,6 @@ parser.add_argument('-b', '--base_data_version', type=int,
 parser.add_argument('-e', '--export_uuid', required=False, type=str,
                     help='Optional export UUID to retrieve export metadata for. '
                          'If provided, a DV export job will not be scheduled.')
-parser.add_argument('-m', '--mode', choices=['legacy', 'sdk'], default='legacy',
-                    help='Run the DV Export using the legacy methods or through the SDK.')
 
 args = parser.parse_args()
 if args.data_version is None and args.export_uuid is None:
@@ -50,173 +42,28 @@ max_num_polls = int(config_dict[JOB_STATUS_NUM_POLLS])
 poll_interval_seconds = int(config_dict[JOB_STATUS_POLL_INTERVAL_SECONDS])
 delete_downloaded_files = True if config_dict[DELETE_BASE_DOWNLOAD_DIRECTORY_AFTER_EXPORT].upper() == 'TRUE' else False
 base_download_directory = config_dict[BASE_DOWNLOAD_DIRECTORY]
-#store = SQLAlchemyDataStore(config_dict[DB_URL])
+store = SQLAlchemyDataStore(config_dict[DB_URL])
 
-if args.mode == 'legacy':
+config = Configuration.from_dict(config_dict)
+client = ApiClient(config)
 
+dv_export = DVExport(client, store, base_download_directory)
 
-    logger.info("Running DV Export in legacy mode...")
-    store = SQLAlchemyDataStore(config_dict[DB_URL])
+if args.export_uuid is None:
 
-    auth = make_auth(env_values=config_dict)
-    with VisierSession(auth) as s:
-        dv_export_client = DVExportApiClient(s, raise_on_error=True)
-        dv_export = DVExport(dv_export_client, store, base_download_directory)
+    # Schedule a new export job
+    dv_export_schedule_job_request_dto = DataVersionExportScheduleJobRequestDTO(
+        data_version_number=str(args.data_version),
+        base_data_version_number=str(args.base_data_version) if args.base_data_version is not None else None
+    )
 
-        if args.export_uuid is None:
-            data_version_info = DataVersions(
-                int(args.data_version),
-                int(args.base_data_version) if args.base_data_version is not None else None
-            )
-            export_metadata = dv_export.generate_data_version_export(data_version_info,
-                                                                     max_num_polls,
-                                                                     poll_interval_seconds)
-        else:
-            export_metadata = dv_export.get_export_metadata(args.export_uuid)
+    export_metadata = dv_export.generate_data_version_export(dv_export_schedule_job_request_dto, max_num_polls, poll_interval_seconds)
+    logger.info(f"Export metadata generated with export_uuid={export_metadata.uuid}")
 
-        dv_export.process_metadata(export_metadata)
+else:
+    export_metadata = dv_export.get_export_metadata(args.export_uuid)
 
-        if delete_downloaded_files:
-            shutil.rmtree(base_download_directory)
+dv_export.process_metadata(export_metadata)
 
-elif args.mode == 'sdk':
-    from dv_export_model import convert_table_metadata_into_table_infos, FileInfo
-
-    logger.info("Running DV Export using the SDK...")
-    config_dict[DB_URL] = 'sqlite:///j1r-export-sdk-7000001.db'
-    store = SQLAlchemyDataStore(config_dict[DB_URL])
-
-    config = Configuration.from_dict(config_dict)
-    client = ApiClient(config)
-
-    class DVExportNew(DVExport):
-        """ Wrapper class that interacts with the data version export APIs through the SDK."""
-
-        def __init__(self, client: ApiClient, data_store: DataStore, base_download_directory: str):
-            self.client = DataVersionExportApi(client)
-            self.data_store = data_store
-            self.base_download_dir = base_download_directory
-
-        def generate_data_version_export(self,
-                                         dv_export_schedule_job_request_dto: DataVersionExportScheduleJobRequestDTO,
-                                         max_num_polls: int,
-                                         poll_interval_secs: int
-                                         ):
-            job_id = self._schedule_export_job(dv_export_schedule_job_request_dto)
-            export_id = self._get_export_id_when_job_finishes(job_id, max_num_polls, poll_interval_secs)
-            return self.get_export_metadata(export_id)
-
-        def _schedule_export_job(self,
-                                 dv_export_schedule_job_request_dto: DataVersionExportScheduleJobRequestDTO):
-            logger.info(f"Scheduling a data version export job for data_version_number={dv_export_schedule_job_request_dto.data_version_number} "
-                        f"base_data_version_number={dv_export_schedule_job_request_dto.base_data_version_number}")
-
-            try:
-                response = self.client.schedule_export_job(dv_export_schedule_job_request_dto)
-                job_id = response.job_uuid
-                logger.info(f"Scheduled data version export job with {job_id=}")
-                return job_id
-            except ApiException as e:
-                raise Exception(f"Failed to schedule data version export job with {dv_export_schedule_job_request_dto=}\n{e.body}", e)
-
-        def _get_export_id_when_job_finishes(self,
-                                             job_id: str,
-                                             max_num_polls: int,
-                                             poll_interval_seconds: int) -> str:
-            export_id = None
-
-            counter = 1
-            while counter <= max_num_polls:
-                try:
-                    job_status = self.client.get_export_job_status(job_id)
-
-                    if job_status.failed:
-                        raise Exception(f"Data version export {job_id=} failed")
-
-                    if job_status.completed:
-                        export_id = job_status.export_uuid
-                        logger.info(f"Export {job_id=} completed with {export_id=}")
-                        break
-
-                    repeat_msg = f"Trying again in {poll_interval_seconds} seconds" if counter <= max_num_polls else ""
-                    logger.info(f"(Attempt {counter} out of {max_num_polls}) {job_id=} is still running. {repeat_msg}")
-                    if repeat_msg:
-                        time.sleep(poll_interval_seconds)
-
-                except ApiException as e:
-                    raise Exception(f"Failed to get export job status for {job_id=} response={repr(job_status)}\n{e.body}", e)
-
-                finally:
-                    counter += 1
-
-            if export_id is None:
-                raise Exception(f"Failed to retrieve export_id after {max_num_polls} attempts")
-            return export_id
-
-        def get_export_metadata(self, export_id: str) -> DataVersionExportDTO:
-            try:
-                response = self.client.get_export(export_id)
-                logger.info(f"Successfully retrieved export metadata for {export_id=}")
-                return response
-            except ApiException as e:
-                raise Exception(f"Failed to get export metadata for {export_id=}\n{e.body}", e)
-
-        def process_metadata(self, metadata: DataVersionExportDTO):
-            export_id = metadata.uuid
-            tables = convert_table_metadata_into_table_infos(metadata.to_dict()['tables'])
-
-            is_initial_export = (len(metadata.tables) if metadata.tables else 0) == (len(metadata.new_tables) if metadata.new_tables else 0)
-
-            if is_initial_export:
-                self._create_and_populate_new_tables(tables, export_id)
-            else:
-                self._handle_delta_export(tables, metadata, export_id)
-
-        def _download_table_files_to_dir(self,
-                                     export_uuid: str,
-                                     tbl_name: str,
-                                     file_infos: list[FileInfo],
-                                     download_directory: str) -> list[str]:
-            file_paths = []
-            for file_info in file_infos:
-                logger.info(f"Downloading file={file_info.name} with id={file_info.file_id} for table={tbl_name}")
-
-                # There are three possible functions to call to download an individual file from the export; in this
-                # case, we're using the first one, but the methods to call the others are provided as examples
-
-                # Method 1: Returns the bytearray of the file
-                r = self.client.call_1_alpha_download_file(export_uuid=export_uuid, file_id=file_info.file_id)
-
-                # Method 2: Returns an ApiResponse with the bytearray as the data
-                #r = self.client.call_1_alpha_download_file_with_http_info(export_uuid=export_uuid, file_id=file_info.file_id).data
-
-                # Method 3: Return the response through a HTTPResponse
-                #r = self.client.call_1_alpha_download_file_without_preload_content(export_uuid=export_uuid, file_id=file_info.file_id).data
-
-                file_path = download_directory + file_info.name
-                with open(file_path, 'wb') as f:
-                    f.write(r)
-                file_paths.append(file_path)
-                logger.info(f"Downloaded file={file_info.name} with id={file_info.file_id} "
-                            f"for table={tbl_name} to file={file_path}")
-            return file_paths
-
-    dv_export = DVExportNew(client, store, base_download_directory)
-
-    if args.export_uuid is None:
-
-        # Schedule a new export job
-        dv_export_schedule_job_request_dto = DataVersionExportScheduleJobRequestDTO(
-            data_version_number=str(args.data_version),
-            base_data_version_number=str(args.base_data_version) if args.base_data_version is not None else None
-        )
-
-        export_metadata = dv_export.generate_data_version_export(dv_export_schedule_job_request_dto, max_num_polls, poll_interval_seconds)
-
-    else:
-        export_metadata = dv_export.get_export_metadata(args.export_uuid)
-
-    dv_export.process_metadata(export_metadata)
-
-    if delete_downloaded_files:
-        shutil.rmtree(base_download_directory)
+if delete_downloaded_files:
+    shutil.rmtree(base_download_directory)

--- a/dv-export/python/export-to-database/main.py
+++ b/dv-export/python/export-to-database/main.py
@@ -2,6 +2,8 @@ import argparse
 import shutil
 
 from dotenv import dotenv_values
+from visier_platform_sdk import ApiClient, Configuration, DataVersionExportApi, DataVersionExportScheduleJobRequestDTO, \
+    DataVersionExportDTO
 from visier.connector import VisierSession, make_auth
 from visier.api import DVExportApiClient
 from data_store import *
@@ -20,12 +22,10 @@ console_handler.setFormatter(logging.Formatter('%(asctime)s [%(levelname)s] %(na
 logger = logging.getLogger()
 logger.addHandler(console_handler)
 
-config = {
+config_dict = {
     **dotenv_values('.env.dv-export'),
     **dotenv_values('.env.visier-auth')
 }
-
-auth = make_auth(env_values=config)
 
 parser = argparse.ArgumentParser(description='DV Export API example script.')
 parser.add_argument('-d', '--data_version', type=int,
@@ -35,35 +35,69 @@ parser.add_argument('-b', '--base_data_version', type=int,
 parser.add_argument('-e', '--export_uuid', required=False, type=str,
                     help='Optional export UUID to retrieve export metadata for. '
                          'If provided, a DV export job will not be scheduled.')
+parser.add_argument('-m', '--mode', choices=['legacy', 'sdk'], default='legacy',
+                    help='Run the DV Export using the legacy methods or through the SDK.')
 
 args = parser.parse_args()
 if args.data_version is None and args.export_uuid is None:
     raise Exception(f"At least one of data_version or export_uuid must be provided")
 
+# Set up some parameters/objects from config used in the operation
+max_num_polls = int(config_dict[JOB_STATUS_NUM_POLLS])
+poll_interval_seconds = int(config_dict[JOB_STATUS_POLL_INTERVAL_SECONDS])
+delete_downloaded_files = True if config_dict[DELETE_BASE_DOWNLOAD_DIRECTORY_AFTER_EXPORT].upper() == 'TRUE' else False
+base_download_directory = config_dict[BASE_DOWNLOAD_DIRECTORY]
+store = SQLAlchemyDataStore(config_dict[DB_URL])
 
-with VisierSession(auth) as s:
-    dv_export_client = DVExportApiClient(s, raise_on_error=True)
+if args.mode == 'legacy':
+    logger.info("Running DV Export in legacy mode...")
 
-    max_num_polls = int(config[JOB_STATUS_NUM_POLLS])
-    poll_interval_seconds = int(config[JOB_STATUS_POLL_INTERVAL_SECONDS])
-    delete_downloaded_files = True if config[DELETE_BASE_DOWNLOAD_DIRECTORY_AFTER_EXPORT].upper() == 'TRUE' else False
-    base_download_directory = config[BASE_DOWNLOAD_DIRECTORY]
+    auth = make_auth(env_values=config_dict)
+    with VisierSession(auth) as s:
+        dv_export_client = DVExportApiClient(s, raise_on_error=True)
+        dv_export = DVExport(dv_export_client, store, base_download_directory)
 
-    store = SQLAlchemyDataStore(config[DB_URL])
-    dv_export = DVExport(dv_export_client, store, base_download_directory)
+        if args.export_uuid is None:
+            data_version_info = DataVersions(
+                int(args.data_version),
+                int(args.base_data_version) if args.base_data_version is not None else None
+            )
+            export_metadata = dv_export.generate_data_version_export(data_version_info,
+                                                                     max_num_polls,
+                                                                     poll_interval_seconds)
+        else:
+            export_metadata = dv_export.get_export_metadata(args.export_uuid)
+
+        dv_export.process_metadata(export_metadata)
+
+        if delete_downloaded_files:
+            shutil.rmtree(base_download_directory)
+
+elif args.mode == 'sdk':
+    logger.info("Running DV Export using the SDK...")
+
+    config = Configuration.from_dict(config_dict)
+    client = ApiClient(config)
+    data_version_export_api = DataVersionExportApi(client)
 
     if args.export_uuid is None:
-        data_version_info = DataVersions(
-            int(args.data_version),
-            int(args.base_data_version) if args.base_data_version is not None else None
+
+        # Schedule a new export job
+        dv_export_schedule_job_request_dto = DataVersionExportScheduleJobRequestDTO(
+            data_version_number=str(args.data_version),
+            base_data_version_number=str(args.base_data_version) if args.base_data_version is not None else None
         )
-        export_metadata = dv_export.generate_data_version_export(data_version_info,
-                                                                 max_num_polls,
-                                                                 poll_interval_seconds)
+        logger.info(f"Scheduling a data version export job for data_version_number={dv_export_schedule_job_request_dto.data_version_number} "
+                    f"base_data_version_number={dv_export_schedule_job_request_dto.base_data_version_number}")
+        response = data_version_export_api.schedule_export_job(dv_export_schedule_job_request_dto)
+
+        # Monitor job status
+
+        # Return export metadata
+        export_metadata: DataVersionExportDTO = data_version_export_api.get_export(export_uuid=response.job_uuid)
+
     else:
-        export_metadata = dv_export.get_export_metadata(args.export_uuid)
+        export_metadata: DataVersionExportDTO = data_version_export_api.get_export(export_uuid=args.export_uuid)
 
-    dv_export.process_metadata(export_metadata)
-
-    if delete_downloaded_files:
-        shutil.rmtree(base_download_directory)
+    # TODO Process the export metadata
+    # TODO cleanup files if needed

--- a/dv-export/python/export-to-database/main.py
+++ b/dv-export/python/export-to-database/main.py
@@ -50,14 +50,10 @@ client = ApiClient(config)
 dv_export = DVExport(client, store, base_download_directory)
 
 if args.export_uuid is None:
-
-    # Schedule a new export job
-    dv_export_schedule_job_request_dto = DataVersionExportScheduleJobRequestDTO(
-        data_version_number=str(args.data_version),
-        base_data_version_number=str(args.base_data_version) if args.base_data_version is not None else None
-    )
-
-    export_metadata = dv_export.generate_data_version_export(dv_export_schedule_job_request_dto, max_num_polls, poll_interval_seconds)
+    export_metadata = dv_export.generate_data_version_export(args.data_version,
+                                                             args.base_data_version,
+                                                             max_num_polls,
+                                                             poll_interval_seconds)
     logger.info(f"Export metadata generated with export_uuid={export_metadata.uuid}")
 
 else:

--- a/dv-export/python/export-to-database/requirements.txt
+++ b/dv-export/python/export-to-database/requirements.txt
@@ -1,5 +1,4 @@
 pandas>=2.2.2
 python-dotenv>=1.0.1
 SQLAlchemy>=2.0.29
-visier_connector>=0.9.18
 visier-platform-sdk>=22222222.99201.2010

--- a/dv-export/python/export-to-database/requirements.txt
+++ b/dv-export/python/export-to-database/requirements.txt
@@ -2,3 +2,4 @@ pandas>=2.2.2
 python-dotenv>=1.0.1
 SQLAlchemy>=2.0.29
 visier_connector>=0.9.18
+visier-platform-sdk>=22222222.99201.2010


### PR DESCRIPTION
This simply migrates the export-to-database example to use the Visier Platform SDK instead.